### PR TITLE
Rails 4 2 compatible

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,6 +1,7 @@
 === 1.0.0
 
-* Compatability with activerecord 4.2.x
+* gemspec is compatible with activerecord 3 & 4
+* Removed composite_primary_keys dependency
 
 === 0.6.1
 

--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,7 @@
+=== 1.0.0
+
+* Compatability with activerecord 4.2.x
+
 === 0.6.1
 
 * Fixing attr_accessible in Migration model.

--- a/active_nutrition.gemspec
+++ b/active_nutrition.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "activerecord",            ">= 3.0", "< 5"
-  s.add_runtime_dependency "rubyzip",                 "~> 1.2"
+  s.add_runtime_dependency "rubyzip",                 "~> 1.0"
   s.add_runtime_dependency "zip-zip",                 "~> 0.3"
-  s.add_runtime_dependency "composite_primary_keys",  "~> 8.1"
+  s.add_runtime_dependency "composite_primary_keys",  "~> 5.0.14"
 end

--- a/active_nutrition.gemspec
+++ b/active_nutrition.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.test_files    = Dir["spec/**/*"]
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "activerecord",            "~> 4.2"
+  s.add_runtime_dependency "activerecord",            ">= 3.0", "< 5"
   s.add_runtime_dependency "rubyzip",                 "~> 1.2"
   s.add_runtime_dependency "zip-zip",                 "~> 0.3"
   s.add_runtime_dependency "composite_primary_keys",  "~> 8.1"

--- a/active_nutrition.gemspec
+++ b/active_nutrition.gemspec
@@ -22,5 +22,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "activerecord",            ">= 3.0", "< 5"
   s.add_runtime_dependency "rubyzip",                 "~> 1.0"
   s.add_runtime_dependency "zip-zip",                 "~> 0.3"
-  s.add_runtime_dependency "composite_primary_keys",  "~> 5.0.14"
 end

--- a/active_nutrition.gemspec
+++ b/active_nutrition.gemspec
@@ -6,6 +6,7 @@ require "version"
 Gem::Specification.new do |s|
   s.name        = "active_nutrition"
   s.version     = ActiveNutrition::VERSION
+  s.licenses    = ['Nonstandard']
   s.authors     = ["Cameron Dutro"]
   s.email       = ["camertron@gmail.com"]
   s.homepage    = "http://github.com/camertron"
@@ -18,7 +19,8 @@ Gem::Specification.new do |s|
   s.test_files    = Dir["spec/**/*"]
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "activerecord", "~> 3.0"
-  s.add_runtime_dependency "rubyzip", "~> 0.9.4"
-  s.add_runtime_dependency "composite_primary_keys", "~> 5.0.12"
+  s.add_runtime_dependency "activerecord",            "~> 4.2"
+  s.add_runtime_dependency "rubyzip",                 "~> 1.2"
+  s.add_runtime_dependency "zip-zip",                 "~> 0.3"
+  s.add_runtime_dependency "composite_primary_keys",  "~> 8.1"
 end

--- a/lib/active_nutrition.rb
+++ b/lib/active_nutrition.rb
@@ -13,7 +13,6 @@ require 'rake'
 require 'json'
 require 'zip/zip'
 require 'active_record'
-require 'composite_primary_keys'
 
 require 'active_nutrition/models'
 require 'active_nutrition/objects'

--- a/lib/active_nutrition/version.rb
+++ b/lib/active_nutrition/version.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 
 module ActiveNutrition
-  VERSION = "0.6.1"
-  USDA_VERSION = "24"
+  VERSION       = "1.0.0"
+  USDA_VERSION  = "24"
 end


### PR DESCRIPTION
DONTMERGE until application dependencies have been released

Upgrade active_nutrition gem to be compatible w/ Rails 3.x and 4.x
